### PR TITLE
Fix Url.setShortUrl() to set the right field

### DIFF
--- a/src/main/java/edu/kpi/testcourse/model/Url.java
+++ b/src/main/java/edu/kpi/testcourse/model/Url.java
@@ -70,11 +70,9 @@ public class Url {
 
   /**
    * Метод який встановлює значеня короткого посилання.
-   *
-   * @param longUrl - довге посилання.
    */
-  public void setShortUrl(String longUrl) {
-    this.longUrl = longUrl;
+  public void setShortUrl(String shortUrl) {
+    this.shortUrl = shortUrl;
   }
 
   /**


### PR DESCRIPTION
Fix `Url.setShortUrl()` to set the right field.

With this fix, the signup-signin-shorten-redirect workflow works.